### PR TITLE
refactor(tui): replace abandoned dashing dependency with stdlib module

### DIFF
--- a/asitop/asitop.py
+++ b/asitop/asitop.py
@@ -9,9 +9,8 @@ import time
 import tty
 from types import SimpleNamespace
 
-from dashing import HChart, HGauge, HSplit, VGauge, VSplit
-
 from .parsers import CPUMetrics, GpuMetricsOut, display_power_watts, format_extended_status
+from .tui import HChart, HGauge, HSplit, VGauge, VSplit
 from .utils import (
     cleanup_powermetrics,
     clear_console,
@@ -329,9 +328,9 @@ def main() -> tuple[subprocess.Popen[bytes], str]:
 
                     if args.show_cores:
                         for core_count, i in enumerate(cpu_metrics_dict["e_core"]):
-                            e_core_gauges[core_count % 4].title = (
-                                f"Core-{i + 1} {cpu_metrics_dict[f'E-Cluster{i}_active']}%"
-                            )
+                            e_core_gauges[
+                                core_count % 4
+                            ].title = f"Core-{i + 1} {cpu_metrics_dict[f'E-Cluster{i}_active']}%"
                             e_core_gauges[core_count % 4].value = int(
                                 cpu_metrics_dict[f"E-Cluster{i}_active"]
                             )
@@ -344,9 +343,9 @@ def main() -> tuple[subprocess.Popen[bytes], str]:
                             prefix = "Core-" if p_core_count < MIN_P_CORES_ABBREVIATED else "C-"
                             gauge_idx = core_count % MAX_P_CORES_SINGLE_ROW
                             core_key = f"P-Cluster{i}_active"
-                            core_gauges[gauge_idx].title = (
-                                f"{prefix}{i + 1} {cpu_metrics_dict[core_key]}%"
-                            )
+                            core_gauges[
+                                gauge_idx
+                            ].title = f"{prefix}{i + 1} {cpu_metrics_dict[core_key]}%"
                             core_gauges[gauge_idx].value = int(cpu_metrics_dict[core_key])
 
                     gpu_power_w = display_power_watts(

--- a/asitop/asitop.py
+++ b/asitop/asitop.py
@@ -328,9 +328,9 @@ def main() -> tuple[subprocess.Popen[bytes], str]:
 
                     if args.show_cores:
                         for core_count, i in enumerate(cpu_metrics_dict["e_core"]):
-                            e_core_gauges[
-                                core_count % 4
-                            ].title = f"Core-{i + 1} {cpu_metrics_dict[f'E-Cluster{i}_active']}%"
+                            e_core_gauges[core_count % 4].title = (
+                                f"Core-{i + 1} {cpu_metrics_dict[f'E-Cluster{i}_active']}%"
+                            )
                             e_core_gauges[core_count % 4].value = int(
                                 cpu_metrics_dict[f"E-Cluster{i}_active"]
                             )
@@ -343,9 +343,9 @@ def main() -> tuple[subprocess.Popen[bytes], str]:
                             prefix = "Core-" if p_core_count < MIN_P_CORES_ABBREVIATED else "C-"
                             gauge_idx = core_count % MAX_P_CORES_SINGLE_ROW
                             core_key = f"P-Cluster{i}_active"
-                            core_gauges[
-                                gauge_idx
-                            ].title = f"{prefix}{i + 1} {cpu_metrics_dict[core_key]}%"
+                            core_gauges[gauge_idx].title = (
+                                f"{prefix}{i + 1} {cpu_metrics_dict[core_key]}%"
+                            )
                             core_gauges[gauge_idx].value = int(cpu_metrics_dict[core_key])
 
                     gpu_power_w = display_power_watts(

--- a/asitop/tui.py
+++ b/asitop/tui.py
@@ -312,11 +312,13 @@ class HGauge(Tile):
             row_parts.extend((color.escape(), _HBAR_ELEMENTS[-1]))
 
         selector = int((bar_width - int(bar_width)) * 7)
-        row_parts.extend((
-            _HBAR_ELEMENTS[selector],
-            self.text_color.escape(),
-            _HBAR_ELEMENTS[0] * filler_width,
-        ))
+        row_parts.extend(
+            (
+                _HBAR_ELEMENTS[selector],
+                self.text_color.escape(),
+                _HBAR_ELEMENTS[0] * filler_width,
+            )
+        )
 
         for dx in range(tbox.h):
             move = tbox.t.move(tbox.x + dx, tbox.y)

--- a/asitop/tui.py
+++ b/asitop/tui.py
@@ -1,0 +1,395 @@
+"""Terminal dashboard widgets for asitop.
+
+Provides the subset of the former ``dashing`` API used by asitop, implemented
+with the standard library only so the project no longer depends on the
+unmaintained third-party package.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+import colorsys
+import shutil
+import sys
+from typing import NamedTuple, cast
+
+# Box-drawing and bar characters (same repertoire as dashing)
+_BORDER_BL = "└"
+_BORDER_BR = "┘"
+_BORDER_TL = "┌"
+_BORDER_TR = "┐"
+_BORDER_H = "─"
+_BORDER_V = "│"
+_HBAR_ELEMENTS = ("▏", "▎", "▍", "▌", "▋", "▊", "▉")
+_VBAR_ELEMENTS = ("▁", "▂", "▃", "▄", "▅", "▆", "▇", "█")
+
+_ANSI_PALETTE: tuple[tuple[int, int, int], ...] = (
+    (0, 0, 0),
+    (255, 0, 0),
+    (0, 255, 0),
+    (255, 255, 0),
+    (0, 0, 255),
+    (255, 0, 255),
+    (0, 255, 255),
+    (255, 255, 255),
+)
+
+
+class RGB:
+    """An RGB color stored as three integers."""
+
+    __slots__ = ("b", "g", "r")
+
+    def __init__(self, r: int, g: int, b: int) -> None:
+        self.r = r
+        self.g = g
+        self.b = b
+
+    def to_hls(self) -> tuple[float, float, float]:
+        return colorsys.rgb_to_hls(self.r / 255.0, self.g / 255.0, self.b / 255.0)
+
+    def escape(self) -> str:
+        return f"\033[38;2;{self.r};{self.g};{self.b}m"
+
+
+Color = int | str | None | RGB
+
+
+def _init_color(color: Color) -> RGB | None:
+    if color is None:
+        return None
+    if isinstance(color, RGB):
+        return color
+    if isinstance(color, str):
+        if color.startswith("#") and len(color) == 7:
+            return RGB(int(color[1:3], 16), int(color[3:5], 16), int(color[5:7], 16))
+        msg = f"Invalid color string: {color!r}"
+        raise ValueError(msg)
+    if 0 <= color < len(_ANSI_PALETTE):
+        r, g, b = _ANSI_PALETTE[color]
+        return RGB(r, g, b)
+    msg = f"ANSI color index out of range: {color}"
+    raise ValueError(msg)
+
+
+def _interpolate_colors(high: RGB, low: RGB, steps: int, pos: int) -> RGB:
+    start = colorsys.rgb_to_hsv(low.r / 255.0, low.g / 255.0, low.b / 255.0)
+    end = colorsys.rgb_to_hsv(high.r / 255.0, high.g / 255.0, high.b / 255.0)
+    k = pos / float(steps)
+    h = start[0] + (end[0] - start[0]) * k
+    s = start[1] + (end[1] - start[1]) * k
+    v = start[2] + (end[2] - start[2]) * k
+    r, g, b = colorsys.hsv_to_rgb(h, s, v)
+    return RGB(int(r * 255), int(g * 255), int(b * 255))
+
+
+class _Terminal:
+    def __init__(self) -> None:
+        size = shutil.get_terminal_size(fallback=(80, 24))
+        self.width = size.columns
+        self.height = size.lines
+
+    @staticmethod
+    def move(row: int, col: int) -> str:
+        return f"\033[{row + 1};{col + 1}H"
+
+    @staticmethod
+    def color_rgb(r: int, g: int, b: int) -> str:
+        return f"\033[38;2;{r};{g};{b}m"
+
+
+class TBox(NamedTuple):
+    t: _Terminal
+    x: int
+    y: int
+    w: int
+    h: int
+
+
+class _Buf:
+    __slots__ = ("_parts",)
+
+    def __init__(self) -> None:
+        self._parts: list[str] = []
+
+    def add(self, *parts: str) -> None:
+        self._parts.extend(parts)
+
+    def print(self) -> None:
+        sys.stdout.write("".join(self._parts))
+        sys.stdout.flush()
+
+
+class Tile:
+    """Base class for dashboard tiles."""
+
+    title: str
+    items: list[Tile]
+    border: bool
+    parent: Tile | None
+    _terminal: _Terminal | None
+    _text_color: RGB | None
+    _border_color: RGB | None
+    _color_high: RGB | None
+    _color_low: RGB | None
+
+    def __init__(
+        self,
+        title: str = "",
+        border: bool = True,
+        border_color: Color = None,
+        color: Color = None,
+        color_high: Color = None,
+        color_low: Color = None,
+    ) -> None:
+        self.title = title
+        self._terminal = None
+        self.parent = None
+        self.items = []
+        self.border = border
+        self._text_color = _init_color(color)
+        self._border_color = _init_color(border_color)
+        self._color_high = _init_color(color_high)
+        self._color_low = _init_color(color_low)
+
+    def _inherit_color(self, name: str) -> RGB:
+        private = f"_{name}"
+        value = getattr(self, private)
+        if isinstance(value, RGB):
+            return value
+        if self.parent is not None:
+            parent_value = getattr(self.parent, name)
+            return cast("RGB", parent_value)
+        default = RGB(128, 128, 128)
+        setattr(self, private, default)
+        return default
+
+    @property
+    def text_color(self) -> RGB:
+        return self._inherit_color("text_color")
+
+    @property
+    def border_color(self) -> RGB:
+        return self._inherit_color("border_color")
+
+    @property
+    def color_high(self) -> RGB:
+        return self._inherit_color("color_high")
+
+    @property
+    def color_low(self) -> RGB:
+        return self._inherit_color("color_low")
+
+    def _display(self, buf: _Buf, tbox: TBox) -> None:
+        raise NotImplementedError
+
+    def _draw_borders_and_title(self, buf: _Buf, tbox: TBox) -> TBox:
+        if self.border:
+            buf.add(self.border_color.escape())
+            for dx in range(1, tbox.h - 1):
+                buf.add(tbox.t.move(tbox.x + dx, tbox.y), _BORDER_V)
+                buf.add(tbox.t.move(tbox.x + dx, tbox.y + tbox.w - 1), _BORDER_V)
+            buf.add(
+                tbox.t.move(tbox.x + tbox.h - 1, tbox.y),
+                _BORDER_BL,
+                _BORDER_H * (tbox.w - 2),
+                _BORDER_BR,
+            )
+            if self.title:
+                margin = int((tbox.w - len(self.title)) / 20)
+                border_t = _BORDER_H * (margin - 1) + " " * margin + self.title + " " * margin
+                border_t += (tbox.w - len(border_t) - 2) * _BORDER_H
+            else:
+                border_t = _BORDER_H * (tbox.w - 2)
+            buf.add(tbox.t.move(tbox.x, tbox.y), _BORDER_TL, border_t, _BORDER_TR)
+            return TBox(tbox.t, tbox.x + 1, tbox.y + 1, tbox.w - 2, tbox.h - 2)
+
+        if self.title:
+            margin = int((tbox.w - len(self.title)) / 20)
+            title = " " * margin + self.title + " " * (tbox.w - margin - len(self.title))
+            buf.add(tbox.t.move(tbox.x, tbox.y), title)
+            return TBox(tbox.t, tbox.x + 1, tbox.y, tbox.w, tbox.h - 1)
+
+        return tbox
+
+    def _fill_area(self, buf: _Buf, tbox: TBox, char: str) -> None:
+        for dx in range(tbox.h):
+            buf.add(tbox.t.move(tbox.x + dx, tbox.y), char * tbox.w)
+
+    def display(self, terminal: _Terminal | None = None) -> None:
+        if self._terminal is None:
+            self._terminal = terminal or _Terminal()
+        t = self._terminal
+        tbox = TBox(t, 0, 0, t.width, t.height - 1)
+        buf = _Buf()
+        self._display(buf, tbox)
+        buf.add(t.move(t.height - 3, 0), self.border_color.escape())
+        buf.print()
+
+
+class Split(Tile):
+    def __init__(self, *items: Tile, border: bool = False, **kwargs: object) -> None:
+        kwargs["border"] = border
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.items = list(items)
+        self._update_children()
+
+    def _update_children(self) -> None:
+        for item in self.items:
+            item.parent = self
+
+
+class VSplit(Split):
+    def _display(self, buf: _Buf, tbox: TBox) -> None:
+        tbox = self._draw_borders_and_title(buf, tbox)
+        if not self.items:
+            return
+
+        item_height = tbox.h // len(self.items)
+        item_width = tbox.w
+        row = tbox.x
+        for item in self.items:
+            item._display(buf, TBox(tbox.t, row, tbox.y, item_width, item_height))
+            row += item_height
+
+        leftover = tbox.h - row + tbox.x
+        if leftover > 0:
+            self._fill_area(buf, TBox(tbox.t, row, tbox.y, tbox.w, leftover), " ")
+
+
+class HSplit(Split):
+    def _display(self, buf: _Buf, tbox: TBox) -> None:
+        tbox = self._draw_borders_and_title(buf, tbox)
+        if not self.items:
+            return
+
+        item_height = tbox.h
+        item_width = tbox.w // len(self.items)
+        col = tbox.y
+        for item in self.items:
+            item._display(buf, TBox(tbox.t, tbox.x, col, item_width, item_height))
+            col += item_width
+
+        leftover = tbox.w - col + tbox.y
+        if leftover > 0:
+            self._fill_area(buf, TBox(tbox.t, tbox.x, col, leftover - 1, tbox.h), " ")
+
+
+class HGauge(Tile):
+    value: int | float
+    label: str
+
+    def __init__(
+        self,
+        label: str = "",
+        val: float = 100,
+        color: Color = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(color=color, **kwargs)  # type: ignore[arg-type]
+        self.value = val
+        self.label = label
+
+    def _display(self, buf: _Buf, tbox: TBox) -> None:
+        tbox = self._draw_borders_and_title(buf, tbox)
+        if self.label:
+            label_width = len(self.label)
+            bar_width = (tbox.w - label_width - 3) * self.value / 100
+            center_row = int(tbox.h * 0.5)
+            bar_inner_width = int(bar_width)
+            filler_width = tbox.w - bar_inner_width - label_width - 2
+        else:
+            label_width = 0
+            bar_width = tbox.w * self.value / 100.0
+            center_row = None
+            bar_inner_width = int(bar_width)
+            filler_width = tbox.w - bar_inner_width - 1
+
+        row_parts: list[str] = []
+        total_width = bar_inner_width + filler_width
+        for pos in range(bar_inner_width):
+            color = _interpolate_colors(self.color_high, self.color_low, total_width, pos)
+            row_parts.extend((color.escape(), _HBAR_ELEMENTS[-1]))
+
+        selector = int((bar_width - int(bar_width)) * 7)
+        row_parts.extend((
+            _HBAR_ELEMENTS[selector],
+            self.text_color.escape(),
+            _HBAR_ELEMENTS[0] * filler_width,
+        ))
+
+        for dx in range(tbox.h):
+            move = tbox.t.move(tbox.x + dx, tbox.y)
+            if self.label:
+                if dx == center_row:
+                    buf.add(move, self.label, " ")
+                else:
+                    buf.add(move, " " * label_width, " ")
+            else:
+                buf.add(move)
+            buf.add(*row_parts)
+
+
+class VGauge(Tile):
+    value: int | float
+
+    def __init__(self, val: float = 100, color: Color = None, **kwargs: object) -> None:
+        super().__init__(color=color, **kwargs)  # type: ignore[arg-type]
+        self.value = val
+
+    def _display(self, buf: _Buf, tbox: TBox) -> None:
+        tbox = self._draw_borders_and_title(buf, tbox)
+        filled_height = tbox.h * (self.value / 100.5)
+        buf.add(tbox.t.move(tbox.x, tbox.y), self.text_color.escape())
+        for dx in range(tbox.h):
+            move = tbox.t.move(tbox.x + tbox.h - dx - 1, tbox.y)
+            buf.add(move)
+            color = _interpolate_colors(self.color_high, self.color_low, tbox.h, dx)
+            buf.add(color.escape())
+            if dx < int(filled_height):
+                buf.add(_VBAR_ELEMENTS[-1] * tbox.w)
+            elif dx == int(filled_height):
+                index = int((filled_height - int(filled_height)) * 8)
+                buf.add(_VBAR_ELEMENTS[index] * tbox.w)
+            else:
+                buf.add(" " * tbox.w)
+
+
+class HChart(Tile):
+    value: int | float
+    datapoints: deque[float]
+
+    def __init__(self, val: float = 100, **kwargs: object) -> None:
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.value = val
+        self.datapoints = deque(maxlen=500)
+
+    def append(self, dp: float) -> None:
+        self.datapoints.append(dp)
+
+    def _chart_char(self, dp: float, row: int, height: int) -> str:
+        q = (1 - dp / 100) * height
+        if row == int(q):
+            index = int((int(q) - q) * 8 - 1)
+            return _VBAR_ELEMENTS[index]
+        if row < int(q):
+            return " "
+        return _VBAR_ELEMENTS[-1]
+
+    def _display(self, buf: _Buf, tbox: TBox) -> None:
+        tbox = self._draw_borders_and_title(buf, tbox)
+        buf.add(self.text_color.escape())
+        for dx in range(tbox.h):
+            bar = ""
+            for dy in range(tbox.w):
+                dp_index = -tbox.w + dy
+                try:
+                    dp = self.datapoints[dp_index]
+                except IndexError:
+                    bar += " "
+                    continue
+                bar += self._chart_char(dp, dx, tbox.h)
+            buf.add(tbox.t.move(tbox.x + dx, tbox.y), bar)
+
+
+__all__ = ["HChart", "HGauge", "HSplit", "VGauge", "VSplit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Operating System :: MacOS",
 ]
 dependencies = [
-    "dashing==0.1.0",
     "psutil==7.2.2",
 ]
 
@@ -93,7 +92,7 @@ strict_optional = true
 # disallow_untyped_defs = false
 # best practice setting
 disallow_untyped_defs = true
-# Global ignore for missing imports (psutil, dashing)
+# Global ignore for missing imports (psutil)
 # TODO: Consider migrating to per-module ignores for better type coverage
 # ignore_missing_imports = true
 # Disable noisy checks that don't add value for this codebase
@@ -104,7 +103,7 @@ no_implicit_reexport = true
 warn_unreachable = true
 
 [[tool.mypy.overrides]]
-module = ["psutil.*", "dashing.*"]
+module = ["psutil.*"]
 ignore_missing_imports = true
 
 [tool.ruff]
@@ -200,6 +199,14 @@ ignore = [
     "PLR0915", # Too many statements - main CLI logic
     "PLR1702", # Too many nested blocks - main event loop
     "T201",    # print statements - CLI tool uses print
+]
+
+# TUI module mirrors the former dashing tile hierarchy
+"asitop/tui.py" = [
+    "FBT001",  # Boolean positional args - matches dashing API
+    "FBT002",
+    "PLR6301", # Tile helpers are instance methods for subclass overrides
+    "SLF001",  # Sibling tiles call _display within the tile hierarchy
 ]
 
 [tool.ruff.lint.pylint]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,54 @@
+"""Smoke tests for the built-in terminal UI widgets."""
+
+from __future__ import annotations
+
+from collections import deque
+from io import StringIO
+from unittest.mock import patch
+
+from asitop.tui import HChart, HGauge, HSplit, VGauge, VSplit
+
+
+class TestTuiWidgets:
+    def test_hgauge_value_and_title(self) -> None:
+        gauge = HGauge(title="CPU", val=0, color=2)
+        gauge.value = 42
+        gauge.title = "CPU: 42%"
+
+        assert gauge.value == 42
+        assert gauge.title == "CPU: 42%"
+
+    def test_vgauge_accepts_int_value(self) -> None:
+        gauge = VGauge(val=0, color=2, border_color=2)
+        gauge.value = 75
+
+        assert gauge.value == 75
+
+    def test_hchart_append_and_datapoints_maxlen(self) -> None:
+        chart = HChart(title="Power", color=2, val=0)
+        chart.datapoints = deque(chart.datapoints, maxlen=3)
+
+        for value in (10, 20, 30, 40):
+            chart.append(float(value))
+
+        assert list(chart.datapoints) == [20.0, 30.0, 40.0]
+
+    def test_split_items_accessible(self) -> None:
+        left = HGauge(title="Left", val=10, color=2)
+        right = HGauge(title="Right", val=20, color=2)
+        ui = HSplit(left, right)
+
+        assert ui.items[0] is left
+        assert ui.items[1] is right
+
+    def test_display_renders_without_error(self) -> None:
+        ui = VSplit(
+            HSplit(HGauge(title="CPU", val=50, color=2), HGauge(title="GPU", val=25, color=2)),
+            HChart(title="Power", color=2, val=0),
+            title="asitop",
+            border_color=2,
+        )
+        ui.items[1].append(33.0)
+
+        with patch("sys.stdout", new_callable=StringIO):
+            ui.display()

--- a/tests/test_type_contracts.py
+++ b/tests/test_type_contracts.py
@@ -1,4 +1,4 @@
-"""Test type contracts to ensure compatibility with typed libraries like dashing.
+"""Test type contracts to ensure compatibility with the asitop TUI widgets.
 
 These tests validate that return values match the expected types for library
 contracts, catching issues that static type checkers find but runtime tests
@@ -51,14 +51,14 @@ def get_sample_powermetrics_data() -> dict[str, Any]:
 
 
 class TestGaugeValueTypes:
-    """Test that all gauge values are properly typed as int for dashing.HGauge/VGauge."""
+    """Test that all gauge values are properly typed as int for HGauge/VGauge."""
 
     @patch("psutil.virtual_memory")
     @patch("psutil.swap_memory")
     def test_ram_gauge_value_is_int(self, mock_swap: MagicMock, mock_ram: MagicMock) -> None:
-        """RAM gauge values must be int for dashing.HGauge compatibility.
+        """RAM gauge values must be int for HGauge compatibility.
 
-        The dashing library's HGauge.value expects int, not float or None.
+        HGauge.value expects int, not float or None.
         This test ensures get_ram_metrics_dict() returns proper types.
         """
         from asitop.utils import get_ram_metrics_dict
@@ -76,14 +76,14 @@ class TestGaugeValueTypes:
         metrics = get_ram_metrics_dict()
 
         # free_percent must be int, not float
-        assert isinstance(
-            metrics["free_percent"], int
-        ), f"free_percent must be int, got {type(metrics['free_percent'])}"
+        assert isinstance(metrics["free_percent"], int), (
+            f"free_percent must be int, got {type(metrics['free_percent'])}"
+        )
 
         # swap_free_percent must be int when swap exists
-        assert isinstance(
-            metrics["swap_free_percent"], int
-        ), f"swap_free_percent must be int, got {type(metrics['swap_free_percent'])}"
+        assert isinstance(metrics["swap_free_percent"], int), (
+            f"swap_free_percent must be int, got {type(metrics['swap_free_percent'])}"
+        )
 
         # Verify the value is in valid range
         assert 0 <= metrics["free_percent"] <= 100
@@ -120,7 +120,7 @@ class TestGaugeValueTypes:
         assert metrics["swap_free_percent"] == 0
 
     def test_cpu_gauge_values_are_int(self) -> None:
-        """CPU gauge values must be int for dashing.HGauge compatibility.
+        """CPU gauge values must be int for HGauge compatibility.
 
         parse_cpu_metrics() returns various *_active and *_freq_Mhz values that
         are assigned to HGauge.value. All must be int, not float.
@@ -136,9 +136,9 @@ class TestGaugeValueTypes:
 
         for key in active_keys:
             value = metrics[key]
-            assert isinstance(
-                value, int
-            ), f"{key} must be int, got {type(value)} with value {value}"
+            assert isinstance(value, int), (
+                f"{key} must be int, got {type(value)} with value {value}"
+            )
             assert 0 <= value <= 100, f"{key} percentage must be 0-100, got {value}"
 
         # All *_freq_Mhz values must be int (these are frequencies)
@@ -147,13 +147,13 @@ class TestGaugeValueTypes:
 
         for key in freq_keys:
             value = metrics[key]
-            assert isinstance(
-                value, int
-            ), f"{key} must be int, got {type(value)} with value {value}"
+            assert isinstance(value, int), (
+                f"{key} must be int, got {type(value)} with value {value}"
+            )
             assert value >= 0, f"{key} frequency must be non-negative, got {value}"
 
     def test_gpu_gauge_values_are_int(self) -> None:
-        """GPU gauge values must be int for dashing.HGauge compatibility.
+        """GPU gauge values must be int for HGauge compatibility.
 
         parse_gpu_metrics() returns 'active' and 'freq_MHz' that are assigned
         to HGauge.value. Both must be int, not float.
@@ -164,18 +164,18 @@ class TestGaugeValueTypes:
         metrics = parse_gpu_metrics(sample_data)
 
         # GPU active percentage must be int
-        assert isinstance(
-            metrics["active"], int
-        ), f"GPU active must be int, got {type(metrics['active'])}"
+        assert isinstance(metrics["active"], int), (
+            f"GPU active must be int, got {type(metrics['active'])}"
+        )
         assert 0 <= metrics["active"] <= 100, f"GPU active must be 0-100, got {metrics['active']}"
 
         # GPU frequency must be int
-        assert isinstance(
-            metrics["freq_MHz"], int
-        ), f"GPU freq_MHz must be int, got {type(metrics['freq_MHz'])}"
-        assert (
-            metrics["freq_MHz"] >= 0
-        ), f"GPU freq_MHz must be non-negative, got {metrics['freq_MHz']}"
+        assert isinstance(metrics["freq_MHz"], int), (
+            f"GPU freq_MHz must be int, got {type(metrics['freq_MHz'])}"
+        )
+        assert metrics["freq_MHz"] >= 0, (
+            f"GPU freq_MHz must be non-negative, got {metrics['freq_MHz']}"
+        )
 
     def test_calculate_gpu_usage_returns_int(self) -> None:
         """calculate_gpu_usage must return int for utilization percentage.
@@ -194,9 +194,9 @@ class TestGaugeValueTypes:
         assert 0 <= gpu_util <= 100, f"GPU utilization must be 0-100, got {gpu_util}"
 
         # freq can be int or None
-        assert gpu_freq is None or isinstance(
-            gpu_freq, int
-        ), f"GPU frequency must be int or None, got {type(gpu_freq)}"
+        assert gpu_freq is None or isinstance(gpu_freq, int), (
+            f"GPU frequency must be int or None, got {type(gpu_freq)}"
+        )
 
         # Test with power-based fallback
         gpu_metrics_idle = {"freq_MHz": 0, "active": 0}
@@ -207,9 +207,9 @@ class TestGaugeValueTypes:
             last_gpu_freq_mhz=1200,
         )
 
-        assert isinstance(
-            gpu_util, int
-        ), f"GPU utilization (power-based) must be int, got {type(gpu_util)}"
+        assert isinstance(gpu_util, int), (
+            f"GPU utilization (power-based) must be int, got {type(gpu_util)}"
+        )
         assert 0 <= gpu_util <= 100, f"GPU utilization must be 0-100, got {gpu_util}"
 
 
@@ -265,9 +265,9 @@ class TestNumericValueRanges:
             if key.endswith("_freq_Mhz"):
                 freq = metrics[key]
                 # Allow 0 for idle, otherwise should be in reasonable range
-                assert (
-                    freq == 0 or 100 <= freq <= 5000
-                ), f"{key} frequency {freq} MHz seems unreasonable"
+                assert freq == 0 or 100 <= freq <= 5000, (
+                    f"{key} frequency {freq} MHz seems unreasonable"
+                )
 
         # Power values should be positive floats
         assert metrics["cpu_W"] >= 0
@@ -400,9 +400,9 @@ class TestReturnValueStructure:
             "swap_free_GB",
             "swap_free_percent",
         }
-        assert (
-            set(metrics.keys()) == required_keys
-        ), f"Missing or extra keys: {set(metrics.keys()) ^ required_keys}"
+        assert set(metrics.keys()) == required_keys, (
+            f"Missing or extra keys: {set(metrics.keys()) ^ required_keys}"
+        )
 
         # Type validation for each key
         expected_types = {
@@ -419,7 +419,7 @@ class TestReturnValueStructure:
         for key, expected_type in expected_types.items():
             actual_type = type(metrics[key])
             assert actual_type == expected_type, (
-                f"{key} should be {expected_type.__name__}, " f"got {actual_type.__name__}"
+                f"{key} should be {expected_type.__name__}, got {actual_type.__name__}"
             )
 
     def test_gpu_metrics_dict_structure(self) -> None:
@@ -431,9 +431,9 @@ class TestReturnValueStructure:
 
         # Required keys
         required_keys = {"freq_MHz", "active"}
-        assert (
-            set(metrics.keys()) == required_keys
-        ), f"Missing or extra keys: {set(metrics.keys()) ^ required_keys}"
+        assert set(metrics.keys()) == required_keys, (
+            f"Missing or extra keys: {set(metrics.keys()) ^ required_keys}"
+        )
 
         # Type validation
         assert isinstance(metrics["freq_MHz"], int)

--- a/tests/test_type_contracts.py
+++ b/tests/test_type_contracts.py
@@ -76,14 +76,14 @@ class TestGaugeValueTypes:
         metrics = get_ram_metrics_dict()
 
         # free_percent must be int, not float
-        assert isinstance(metrics["free_percent"], int), (
-            f"free_percent must be int, got {type(metrics['free_percent'])}"
-        )
+        assert isinstance(
+            metrics["free_percent"], int
+        ), f"free_percent must be int, got {type(metrics['free_percent'])}"
 
         # swap_free_percent must be int when swap exists
-        assert isinstance(metrics["swap_free_percent"], int), (
-            f"swap_free_percent must be int, got {type(metrics['swap_free_percent'])}"
-        )
+        assert isinstance(
+            metrics["swap_free_percent"], int
+        ), f"swap_free_percent must be int, got {type(metrics['swap_free_percent'])}"
 
         # Verify the value is in valid range
         assert 0 <= metrics["free_percent"] <= 100
@@ -136,9 +136,9 @@ class TestGaugeValueTypes:
 
         for key in active_keys:
             value = metrics[key]
-            assert isinstance(value, int), (
-                f"{key} must be int, got {type(value)} with value {value}"
-            )
+            assert isinstance(
+                value, int
+            ), f"{key} must be int, got {type(value)} with value {value}"
             assert 0 <= value <= 100, f"{key} percentage must be 0-100, got {value}"
 
         # All *_freq_Mhz values must be int (these are frequencies)
@@ -147,9 +147,9 @@ class TestGaugeValueTypes:
 
         for key in freq_keys:
             value = metrics[key]
-            assert isinstance(value, int), (
-                f"{key} must be int, got {type(value)} with value {value}"
-            )
+            assert isinstance(
+                value, int
+            ), f"{key} must be int, got {type(value)} with value {value}"
             assert value >= 0, f"{key} frequency must be non-negative, got {value}"
 
     def test_gpu_gauge_values_are_int(self) -> None:
@@ -164,18 +164,18 @@ class TestGaugeValueTypes:
         metrics = parse_gpu_metrics(sample_data)
 
         # GPU active percentage must be int
-        assert isinstance(metrics["active"], int), (
-            f"GPU active must be int, got {type(metrics['active'])}"
-        )
+        assert isinstance(
+            metrics["active"], int
+        ), f"GPU active must be int, got {type(metrics['active'])}"
         assert 0 <= metrics["active"] <= 100, f"GPU active must be 0-100, got {metrics['active']}"
 
         # GPU frequency must be int
-        assert isinstance(metrics["freq_MHz"], int), (
-            f"GPU freq_MHz must be int, got {type(metrics['freq_MHz'])}"
-        )
-        assert metrics["freq_MHz"] >= 0, (
-            f"GPU freq_MHz must be non-negative, got {metrics['freq_MHz']}"
-        )
+        assert isinstance(
+            metrics["freq_MHz"], int
+        ), f"GPU freq_MHz must be int, got {type(metrics['freq_MHz'])}"
+        assert (
+            metrics["freq_MHz"] >= 0
+        ), f"GPU freq_MHz must be non-negative, got {metrics['freq_MHz']}"
 
     def test_calculate_gpu_usage_returns_int(self) -> None:
         """calculate_gpu_usage must return int for utilization percentage.
@@ -194,9 +194,9 @@ class TestGaugeValueTypes:
         assert 0 <= gpu_util <= 100, f"GPU utilization must be 0-100, got {gpu_util}"
 
         # freq can be int or None
-        assert gpu_freq is None or isinstance(gpu_freq, int), (
-            f"GPU frequency must be int or None, got {type(gpu_freq)}"
-        )
+        assert gpu_freq is None or isinstance(
+            gpu_freq, int
+        ), f"GPU frequency must be int or None, got {type(gpu_freq)}"
 
         # Test with power-based fallback
         gpu_metrics_idle = {"freq_MHz": 0, "active": 0}
@@ -207,9 +207,9 @@ class TestGaugeValueTypes:
             last_gpu_freq_mhz=1200,
         )
 
-        assert isinstance(gpu_util, int), (
-            f"GPU utilization (power-based) must be int, got {type(gpu_util)}"
-        )
+        assert isinstance(
+            gpu_util, int
+        ), f"GPU utilization (power-based) must be int, got {type(gpu_util)}"
         assert 0 <= gpu_util <= 100, f"GPU utilization must be 0-100, got {gpu_util}"
 
 
@@ -265,9 +265,9 @@ class TestNumericValueRanges:
             if key.endswith("_freq_Mhz"):
                 freq = metrics[key]
                 # Allow 0 for idle, otherwise should be in reasonable range
-                assert freq == 0 or 100 <= freq <= 5000, (
-                    f"{key} frequency {freq} MHz seems unreasonable"
-                )
+                assert (
+                    freq == 0 or 100 <= freq <= 5000
+                ), f"{key} frequency {freq} MHz seems unreasonable"
 
         # Power values should be positive floats
         assert metrics["cpu_W"] >= 0
@@ -400,9 +400,9 @@ class TestReturnValueStructure:
             "swap_free_GB",
             "swap_free_percent",
         }
-        assert set(metrics.keys()) == required_keys, (
-            f"Missing or extra keys: {set(metrics.keys()) ^ required_keys}"
-        )
+        assert (
+            set(metrics.keys()) == required_keys
+        ), f"Missing or extra keys: {set(metrics.keys()) ^ required_keys}"
 
         # Type validation for each key
         expected_types = {
@@ -418,9 +418,9 @@ class TestReturnValueStructure:
 
         for key, expected_type in expected_types.items():
             actual_type = type(metrics[key])
-            assert actual_type == expected_type, (
-                f"{key} should be {expected_type.__name__}, got {actual_type.__name__}"
-            )
+            assert (
+                actual_type == expected_type
+            ), f"{key} should be {expected_type.__name__}, got {actual_type.__name__}"
 
     def test_gpu_metrics_dict_structure(self) -> None:
         """Validate complete structure of GPU metrics dictionary."""
@@ -431,9 +431,9 @@ class TestReturnValueStructure:
 
         # Required keys
         required_keys = {"freq_MHz", "active"}
-        assert set(metrics.keys()) == required_keys, (
-            f"Missing or extra keys: {set(metrics.keys()) ^ required_keys}"
-        )
+        assert (
+            set(metrics.keys()) == required_keys
+        ), f"Missing or extra keys: {set(metrics.keys()) ^ required_keys}"
 
         # Type validation
         assert isinstance(metrics["freq_MHz"], int)

--- a/uv.lock
+++ b/uv.lock
@@ -3,20 +3,10 @@ revision = 3
 requires-python = "==3.14.6"
 
 [[package]]
-name = "ansicon"
-version = "1.89.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/e2/1c866404ddbd280efedff4a9f15abfe943cb83cde6e895022370f3a61f85/ansicon-1.89.0.tar.gz", hash = "sha256:e4d039def5768a47e4afec8e89e83ec3ae5a26bf00ad851f914d1240b444d2b1", size = 67312, upload-time = "2019-04-29T20:23:57.314Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/f9/f1c10e223c7b56a38109a3f2eb4e7fe9a757ea3ed3a166754fb30f65e466/ansicon-1.89.0-py2.py3-none-any.whl", hash = "sha256:f1def52d17f65c2c9682cf8370c03f541f410c1752d6a14029f97318e4b9dfec", size = 63675, upload-time = "2019-04-29T20:23:53.83Z" },
-]
-
-[[package]]
 name = "asitop"
 version = "0.0.22"
 source = { editable = "." }
 dependencies = [
-    { name = "dashing" },
     { name = "psutil" },
 ]
 
@@ -37,7 +27,6 @@ test = [
 requires-dist = [
     { name = "black", marker = "extra == 'test'", specifier = "==26.5.1" },
     { name = "coverage", marker = "extra == 'test'", specifier = "==7.15.2" },
-    { name = "dashing", specifier = "==0.1.0" },
     { name = "mypy", extras = ["native-parser"], marker = "extra == 'test'", specifier = "==2.3.0" },
     { name = "psutil", specifier = "==7.2.2" },
     { name = "pyright", marker = "extra == 'test'", specifier = "==1.1.411" },
@@ -113,19 +102,6 @@ wheels = [
 ]
 
 [[package]]
-name = "blessed"
-version = "1.42.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinxed" },
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/48/27ed9ee1a574c96453a20f2024d385ec4c33ffeef180faab744c666e7dcd/blessed-1.42.0.tar.gz", hash = "sha256:34b460b77562ed21f807cfd7c527b983b0cc300c98810c8076f283b7bcd45ba7", size = 14025805, upload-time = "2026-05-20T16:03:18.293Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/46/c41f906f2488e14ab65ac77101f9511779fb28c653484bd79ac13f2f21ee/blessed-1.42.0-py3-none-any.whl", hash = "sha256:f96c4a6dc664b48e0b832fa732acc16df67abd30f0ec35babf99025982f21852", size = 129863, upload-time = "2026-05-20T16:03:15.622Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -186,33 +162,12 @@ wheels = [
 ]
 
 [[package]]
-name = "dashing"
-version = "0.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "blessed" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/01/1c966934ab5ebe5a8fa3012c5de32bfa86916dba0428bdc6cdfe9489f768/dashing-0.1.0.tar.gz", hash = "sha256:2514608e0f29a775dbd1b1111561219ce83d53cfa4baa2fe4101fab84fd56f1b", size = 9637, upload-time = "2020-05-29T13:59:13.967Z" }
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
-name = "jinxed"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ansicon", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/eb/8821ce6e7386e96355f2c6be83944925b4a0870572896fd33a4e61b8aa5a/jinxed-2.0.0.tar.gz", hash = "sha256:64b960b8f8d9966e1b2e7cb57ea2b1aa0a8d7e68045b96dc7ef58201e43a1209", size = 127118, upload-time = "2026-05-08T21:25:25.917Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/00/b61668fd3b1e43b445979ec9a9e0af4781bf06884937d1e906f6a1be6dff/jinxed-2.0.0-py2.py3-none-any.whl", hash = "sha256:b3df1be5262a37145ef42875a8bbf918f1a563fbd035359650dd9fc0bb2b9294", size = 95364, upload-time = "2026-05-08T21:25:24.536Z" },
 ]
 
 [[package]]
@@ -481,13 +436,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "wcwidth"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]


### PR DESCRIPTION
Remove the unmaintained dashing==0.1.0 package and its transitive dependencies (blessed, wcwidth, jinxed, ansicon). asitop now ships a built-in terminal UI module that implements the subset of the dashing API the app actually uses.

Motivation:
- dashing has seen little maintenance since 2020 and is flagged as an unmaintained dependency in project security review
- Keeping the external dependency added supply-chain surface area for no benefit, since only a small API surface was used

Implementation:
- Add asitop/tui.py with drop-in replacements for HGauge, VGauge, HSplit, VSplit, and HChart
- Render via ANSI escape sequences and shutil.get_terminal_size(); no new third-party runtime dependencies
- Preserve existing widget behavior: bordered tiles, gradient gauges, scrolling power charts, and dynamic title/value updates
- Switch asitop/asitop.py to import widgets from asitop.tui

Dependency and tooling updates:
- Remove dashing from pyproject.toml; psutil remains the sole production dependency
- Regenerate uv.lock
- Drop mypy ignore for dashing.*
- Add ruff per-file ignores for asitop/tui.py where the tile hierarchy intentionally mirrors the former dashing API

Tests:
- Add tests/test_tui.py smoke tests for gauge/chart/split widgets and display rendering
- Update tests/test_type_contracts.py docstrings to reference the internal TUI instead of dashing

No user-facing CLI behavior change is intended; this is an internal dependency replacement with API-compatible widgets.